### PR TITLE
update readme with correct permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ To access the ACCOUNT_USAGE share, an account administrator must grant the user 
 As an example, The commands below would be used if the user in your looker connection was granted the "looker_role" and that is how you plan on permissioning the SNOWFLAKE shared DB:
 
 ```
-grant usage on database SNOWFLAKE to role looker_role;
-grant usage on schema SNOWFLAKE.ACCOUNT_USAGE to role looker_role;
-grant select on all tables in schema SNOWFLAKE.ACCOUNT_USAGE to role looker_role;
+grant imported privileges on database SNOWFLAKE to role looker_role;
+grant select on all views in schema SNOWFLAKE.ACCOUNT_USAGE to role looker_role;
 ```
 
 


### PR DESCRIPTION
According to a [customer report](https://buganizer.corp.google.com/issues/220866150), the permission steps are incorrect. For reference:

```
1. grant usage on database SNOWFLAKE to role looker_role;
2. grant usage on schema SNOWFLAKE.ACCOUNT_USAGE to role looker_role;
3. grant select on all tables in schema SNOWFLAKE.ACCOUNT_USAGE to role looker_role;
```

Reportedly, step 1 is incorrect because the databased is shared, therefore we need to grant "imported privileges" instead of "usage". That also renders step 2 unnecessary. Finally, the schema SNOWFLAKE.ACCOUNT_USAGE only contains views, not tables, so step 3 needs to be updated.